### PR TITLE
Add more contributing details to introduction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,22 @@ The source for the _unofficial_ Discord API documentation.
 - Clone the repository: `$ git clone https://github.com/apacheli/community-docs`
 - [Install mdBook](https://rust-lang.github.io/mdBook/guide/installation.html)
 - [Install dprint](https://dprint.dev/install/)
-- Run the formatter from the root of the directory: `$ dprint fmt`
-- Run the checker to make sure everything is formatted: `$ dprint check`
 - Run the documentation locally: `$ mdbook serve`
-- Create a pull request
+- Make the necessary changes. See [the style guide](#style-guide) for more
+  information.
+- Run the formatter from the root of the directory: `$ dprint fmt`
+- Run the checker to make sure that everything is formatted: `$ dprint check`
+- Create a pull request.
 
 By contributing to this repository, you agree to the terms of
 [the community-docs license](./LICENSE).
+
+### Style Guide
+
+- The documentation should compliment the already existing
+  [Discord Developer Documentation](https://discord.com/developers/docs/intro).
+- Each page should flow smoothly from top to bottom.
+- Do not use contractions (e.g. prefer _do not_ over _don't_).
 
 ### Useful Links
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,5 +1,3 @@
 # Unofficial Discord API Documentation
 
 [Introduction](./introduction.md)
-
-- [Chapter 1]()

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,4 +1,15 @@
 # Introduction
 
 Welcome to the _unofficial_ Discord API documentation. The aim of this project
-is to explain the concepts of the Discord API in more detail.
+is to explain the concepts of the Discord API in more detail. If you are still
+confused about a concept that we have explained here, please don't hesitate to
+join the [Discord API server](https://discord.gg/discord-api) to ask for help.
+We want to make the documentation as clear and as concise as possible.
+
+## Contributing
+
+Found a grammatical error or a misspelling? Please help us by
+[creating a pull request](https://github.com/apacheli/community-docs/pulls) with
+the necessary changes. We love contributions! See
+[our contributing guidelines](https://github.com/apacheli/community-docs#contributing)
+for more information.


### PR DESCRIPTION
I added a style guide to help make the documentation more grammatically consistent. I also made the introduction page look nicer. Also, should we add the "Official Unofficial API" banner to the introduction page?

<img height="200px" src="https://miro.medium.com/max/1400/1*s5Ag5S4nAhPB90reG8Ud5g.png">
